### PR TITLE
dateTo fixed to use endOfDay instead of startOfDay

### DIFF
--- a/src/jquery-rangepicker.js
+++ b/src/jquery-rangepicker.js
@@ -476,7 +476,7 @@
                     dateTo = currentDate.endOfDay();
 
                     if (dateFrom > dateTo) {
-                        var tmp = dateFrom.startOfDay();
+                        var tmp = dateFrom.endOfDay();
                         dateFrom = dateTo.startOfDay();
                         dateTo = tmp;
                     }
@@ -560,8 +560,6 @@
                 selectingLast = false;
                 periodType = PERIOD_CUSTOM;
             }
-
-            console.log('after', periodType);
         };
 
         /*


### PR DESCRIPTION
This fixes a bug where if you select a date first which is greater then the date selected second the time period is 00:00-00:00 instead of 00:00-23:59
